### PR TITLE
Move launcher dependency updates to UnchainedChivalry2Launcher

### DIFF
--- a/UnchainedLauncher.Core/Processes/Chivalry/Chivalry2ServerProcessLauncher.cs
+++ b/UnchainedLauncher.Core/Processes/Chivalry/Chivalry2ServerProcessLauncher.cs
@@ -14,8 +14,8 @@ namespace UnchainedLauncher.Core.Processes.Chivalry {
             ExtraArgs = extraArgs;
         }
 
-        public LanguageExt.Option<LanguageExt.Either<ProcessLaunchFailure, Process>> Launch() {
-            var launch = Launcher.Launch(ModdedLaunchOptions, ExtraArgs);
+        public LanguageExt.Option<LanguageExt.Either<UnchainedLaunchFailure, Process>> Launch() {
+            var launch = Launcher.Launch(ModdedLaunchOptions, true, ExtraArgs);
             return launch;
         }
     }

--- a/UnchainedLauncher.Core/Processes/Chivalry/ClientSideModdedOfficialChivalry2Launcher.cs
+++ b/UnchainedLauncher.Core/Processes/Chivalry/ClientSideModdedOfficialChivalry2Launcher.cs
@@ -14,7 +14,7 @@ namespace UnchainedLauncher.Core.Processes.Chivalry {
             Launcher = processLauncher;
         }
 
-        public Either<ProcessLaunchFailure, Process> Launch(string args) {
+        public Either<LaunchFailed, Process> Launch(string args) {
             logger.Info("Attempting to launch vanilla game with pak loading.");
             logger.LogListInfo("Launch args: ", args);
 
@@ -23,10 +23,7 @@ namespace UnchainedLauncher.Core.Processes.Chivalry {
             var launchResult = Launcher.Launch(WorkingDirectory, args);
 
             launchResult.Match(
-                Left: error => error.Match(
-                    LaunchFailedError: e => logger.Error($"Failed to launch Chivalry 2. {e.ExecutablePath} {e.Args}", e.Underlying),
-                    InjectionFailedError: e => logger.Error($"This should be impossible. Report a bug please", e.Underlying)
-                ),
+                Left: error => logger.Error(error),
                 Right: _ => logger.Info("Successfully launched Chivalry 2.")
             );
 

--- a/UnchainedLauncher.Core/Processes/Chivalry/IOfficialChivalry2Launcher.cs
+++ b/UnchainedLauncher.Core/Processes/Chivalry/IOfficialChivalry2Launcher.cs
@@ -11,6 +11,6 @@ namespace UnchainedLauncher.Core.Processes.Chivalry {
         /// Left if the game failed to launch.
         /// Right if the game was launched successfully.
         /// </returns>
-        public Either<ProcessLaunchFailure, Process> Launch(string args);
+        public Either<LaunchFailed, Process> Launch(string args);
     }
 }

--- a/UnchainedLauncher.Core/Processes/Chivalry/IUnchainedChivalry2Launcher.cs
+++ b/UnchainedLauncher.Core/Processes/Chivalry/IUnchainedChivalry2Launcher.cs
@@ -1,18 +1,37 @@
 ﻿using LanguageExt;
+using LanguageExt.Common;
 using System.Diagnostics;
+using static LanguageExt.Prelude;
 
 namespace UnchainedLauncher.Core.Processes.Chivalry {
     public interface IUnchainedChivalry2Launcher {
         /// <summary>
         /// Launches a modded instance of the game with additional parameters, supporting server hosting and potentially
-        /// DLL Injection.
+        /// DLL Injection.  
         /// </summary>
         /// <param name="launchOptions"></param>
+        /// <param name="updateUnchainedDependencies"></param> If updateUnchainedDependencies is true, the implementation is expected to download updates for required launch files.
         /// <param name="args"></param>
         /// <returns>
         /// Left if the game failed to launch.
         /// Right if the game was launched successfully.
         /// </returns>
-        public Either<ProcessLaunchFailure, Process> Launch(ModdedLaunchOptions launchOptions, string args);
+        public Either<UnchainedLaunchFailure, Process> Launch(ModdedLaunchOptions launchOptions, bool updateUnchainedDependencies, string args);
     }
+
+    public abstract record UnchainedLaunchFailure(string Message, int Code, Option<Error> Underlying): Expected(Message, Code, Underlying) {
+        
+        public record InjectionFailedError(Option<IEnumerable<string>> DllPaths, Error Cause) : UnchainedLaunchFailure($"Failed to inject DLLs '{string.Join("', '", DllPaths)}'", 0, Some(Cause));
+        public record LaunchFailedError(LaunchFailed Failure): UnchainedLaunchFailure(Failure.Message, Failure.Code, Failure.Underlying);
+        public record DependencyDownloadFailedError(IEnumerable<string> DependencyNames)
+            : UnchainedLaunchFailure($"Failed to download dependencies '{string.Join("', '", DependencyNames)}'", 0, None);
+        
+        public static UnchainedLaunchFailure InjectionFailed(Option<IEnumerable<string>> dllPaths, Error cause) =>
+            new InjectionFailedError(dllPaths, cause);
+        public static UnchainedLaunchFailure LaunchFailed(LaunchFailed failure) => new LaunchFailedError(failure);
+        public static UnchainedLaunchFailure DependencyDownloadFailed(IEnumerable<string> dependencyNames) => 
+            new DependencyDownloadFailedError(dependencyNames);
+    }
+    
+
 }

--- a/UnchainedLauncher.Core/Processes/Chivalry/ModdedLaunchOptions.cs
+++ b/UnchainedLauncher.Core/Processes/Chivalry/ModdedLaunchOptions.cs
@@ -4,7 +4,6 @@ using UnchainedLauncher.Core.JsonModels.Metadata.V3;
 namespace UnchainedLauncher.Core.Processes.Chivalry {
     public record ModdedLaunchOptions(
         string ServerBrowserBackend,
-        Option<IEnumerable<Release>> EnabledMods,
         Option<string> SavedDirSuffix,
         Option<ServerLaunchOptions> ServerLaunchOptions
     ) {
@@ -13,8 +12,10 @@ namespace UnchainedLauncher.Core.Processes.Chivalry {
                 $"--server-browser-backend {ServerBrowserBackend}"
             };
             ServerLaunchOptions.IfSome(opts => args.AddRange(opts.ToCLIArgs()));
-            EnabledMods.IfSome(mods => args.AddRange(mods.Select(mod => $"--mod {mod.Manifest.RepoUrl}")));
-            SavedDirSuffix.IfSome(suffix => args.Add($"--saved-dir-suffix {suffix}"));
+            
+            var suffix = SavedDirSuffix.IfNone("Unchained");
+            args.Add($"--saved-dir-suffix {suffix}");
+            
             return args;
         }
     };

--- a/UnchainedLauncher.Core/Processes/Chivalry/OfficialChivalry2Launcher.cs
+++ b/UnchainedLauncher.Core/Processes/Chivalry/OfficialChivalry2Launcher.cs
@@ -14,7 +14,7 @@ namespace UnchainedLauncher.Core.Processes.Chivalry {
             Launcher = processLauncher;
         }
 
-        public Either<ProcessLaunchFailure, Process> Launch(string args) {
+        public Either<LaunchFailed, Process> Launch(string args) {
 
             logger.Info("Attempting to launch vanilla game.");
             logger.LogListInfo("Launch args: ", args);
@@ -24,10 +24,7 @@ namespace UnchainedLauncher.Core.Processes.Chivalry {
             var launchResult = Launcher.Launch(WorkingDirectory, string.Join(" ", args));
 
             launchResult.Match(
-                Left: error => error.Match(
-                    LaunchFailedError: e => logger.Error($"Failed to launch Chivalry 2. {e.ExecutablePath} {e.Args}", e.Underlying),
-                    InjectionFailedError: e => logger.Error($"This should be impossible. Report a bug please", e.Underlying)
-                ),
+                Left: e => logger.Error(e),
                 Right: _ => logger.Info("Successfully launched Chivalry 2.")
             );
 

--- a/UnchainedLauncher.Core/Processes/Chivalry/UnchainedChivalry2Launcher.cs
+++ b/UnchainedLauncher.Core/Processes/Chivalry/UnchainedChivalry2Launcher.cs
@@ -1,7 +1,10 @@
 ﻿using LanguageExt;
 using log4net;
+using Semver;
 using System.Diagnostics;
 using UnchainedLauncher.Core.Extensions;
+using UnchainedLauncher.Core.JsonModels.Metadata.V3;
+using UnchainedLauncher.Core.Mods;
 using UnchainedLauncher.Core.Utilities;
 
 namespace UnchainedLauncher.Core.Processes.Chivalry {
@@ -11,17 +14,35 @@ namespace UnchainedLauncher.Core.Processes.Chivalry {
         private static readonly ILog logger = LogManager.GetLogger(nameof(UnchainedLauncher));
 
         private IProcessLauncher Launcher { get; }
+        private IModManager ModManager { get; }
+        private IReleaseLocator PluginReleaseLocator { get; }
         private Func<IEnumerable<string>> FetchDLLs { get; }
+        private IVersionExtractor<string> FileVersionExtractor { get; }
+        private IUpdateNotifier UpdateNotifier { get; }
+        private IUserDialogueSpawner UserDialogueSpawner { get; }
         private string InstallationRootDir { get; }
 
-        public UnchainedChivalry2Launcher(IProcessLauncher processLauncher, string installationRootDir,
+        public UnchainedChivalry2Launcher(
+            IProcessLauncher processLauncher, 
+            IModManager modManager,
+            IReleaseLocator pluginReleaseLocator,
+            IVersionExtractor<string> fileVersionExtractor,
+            IUpdateNotifier updateNotifier,
+            IUserDialogueSpawner userDialogueSpawner,
+            string installationRootDir,
             Func<IEnumerable<string>> dlls) {
+            
             FetchDLLs = dlls;
             InstallationRootDir = installationRootDir;
             Launcher = processLauncher;
+            ModManager = modManager;
+            PluginReleaseLocator = pluginReleaseLocator;
+            FileVersionExtractor = fileVersionExtractor;
+            UpdateNotifier = updateNotifier;
+            UserDialogueSpawner = userDialogueSpawner;
         }
 
-        public Either<ProcessLaunchFailure, Process> Launch(ModdedLaunchOptions launchOptions, string args) {
+        public Either<UnchainedLaunchFailure, Process> Launch(ModdedLaunchOptions launchOptions, bool updateUnchainedDependencies, string args) {
             logger.Info("Attempting to launch modded game.");
 
             var moddedLaunchArgs = args;
@@ -32,10 +53,15 @@ namespace UnchainedLauncher.Core.Processes.Chivalry {
 
             moddedLaunchArgs.Insert(offsetIndex, " " + launchOpts);
 
-            if (!moddedLaunchArgs.Contains("--saveddirsuffix"))
-                moddedLaunchArgs += " --saveddirsuffix=Unchained";
-
             PrepareModdedLaunchSigs();
+            var updateTask = PrepareUnchainedLaunch(updateUnchainedDependencies);
+            updateTask.Wait();
+            var updateResult = updateTask.Result;
+
+            if (updateResult == false) {
+                logger.Error("Failed to launch modded game.");
+            }
+            
 
             logger.Info($"Launch args: {moddedLaunchArgs}");
 
@@ -43,14 +69,8 @@ namespace UnchainedLauncher.Core.Processes.Chivalry {
 
             return launchResult.Match(
                 Left: error => {
-                    error.Match(
-                        LaunchFailedError: e =>
-                            logger.Error($"Failed to launch Chivalry 2 Unchained. {e.ExecutablePath} {e.Args}",
-                                e.Underlying),
-                        InjectionFailedError: e =>
-                            logger.Error($"Failed to inject DLLs into Chivalry 2 Unchained. {e.DllPaths}", e.Underlying)
-                    );
-                    return Prelude.Left(error);
+                    logger.Error(error);
+                    return Left(UnchainedLaunchFailure.LaunchFailed(error));
                 },
                 Right: proc => {
                     logger.Info("Successfully launched Chivalry 2 Unchained");
@@ -58,8 +78,112 @@ namespace UnchainedLauncher.Core.Processes.Chivalry {
                 }
             );
         }
+        
+        private async Task<bool> PrepareUnchainedLaunch(bool updateDependencies) {
+            var pluginPath = Path.Combine(Directory.GetCurrentDirectory(), FilePaths.UnchainedPluginPath);
+            var pluginExists = File.Exists(pluginPath);
+            var isUnchainedModsEnabled = ModManager.EnabledModReleases.Exists(IsUnchainedMods);
+            
+            if (!updateDependencies && pluginExists && isUnchainedModsEnabled) return true;
 
-        private Either<ProcessLaunchFailure, Process> InjectDLLs(Process process) {
+            var latestPlugin = await PluginReleaseLocator.GetLatestRelease();
+            SemVersion? currentPluginVersion = FileVersionExtractor.GetVersion(pluginPath);
+            
+            var unchainedModsUpdateCandidate = ModManager.GetUpdateCandidates().Find(x => IsUnchainedMods(x.AvailableUpdate)).FirstOrDefault();
+
+            var pluginDependencyUpdate =
+                (currentPluginVersion != null && currentPluginVersion.ComparePrecedenceTo(latestPlugin.Version) >= 0)
+                    ? null
+                    : new DependencyUpdate(
+                        "UnchainedPlugin.dll",
+                        Optional(currentPluginVersion?.ToString()),
+                        latestPlugin.Version.ToString(),
+                        latestPlugin.PageUrl,
+                        "Used for hosting and connecting to player owned servers. Required to run Chivalry 2 Unchained."
+                    );
+
+            var unchainedModsDependencyUpdate =
+                (isUnchainedModsEnabled && unchainedModsUpdateCandidate == null)
+                    ? null
+                    : DependencyUpdate.FromUpdateCandidate(unchainedModsUpdateCandidate!);
+
+            IEnumerable<DependencyUpdate> updates =
+                new List<DependencyUpdate?>() { unchainedModsDependencyUpdate, pluginDependencyUpdate }
+                    .Filter(x => x != null)!;
+            
+
+
+            var titleString = pluginExists
+                ? "Update Required Unchained Dependencies"
+                : "Install Required Unchained Dependencies";
+
+            var messageText = pluginExists
+                ? "Updates for the Unchained Dependencies are available."
+                : "The Unchained Dependencies are not installed.";
+
+
+            var userResponse = UpdateNotifier.Notify(
+                titleString,
+                messageText,
+                "Yes",
+                "No",
+                "Cancel",
+                updates
+            );
+
+            // The cases in here are all for exiting early.
+            switch (userResponse) {
+                // No updates available, continue launch
+                case null:
+                    return true;
+                
+                // Continue launch, don't download or install anything
+                case UserDialogueChoice.No:
+                    return true;
+                
+                // Do not continue launch, don't download or install anything
+                case UserDialogueChoice.Cancel:
+                    return false;
+                
+                // User selected yes/ok. Continue to download
+                case UserDialogueChoice.Yes:
+                    break;
+            }
+            
+            logger.Info("Updating Unchained Dependencies");
+
+            if (pluginDependencyUpdate != null) {
+                var downloadResult = await HttpHelpers.DownloadReleaseTarget(
+                    latestPlugin,
+                    asset => (asset.Name == "UnchainedPlugin.dll") ? pluginPath : null
+                );
+
+                if (downloadResult == false) {
+                    UserDialogueSpawner.DisplayMessage(
+                        "Failed to download Unchained Plugin. Aborting launch. Check the logs for more details.");
+                    return false;
+                }
+            }
+
+            if (unchainedModsDependencyUpdate != null) {
+                var result = await ModManager.EnableModRelease(unchainedModsUpdateCandidate!.AvailableUpdate, None, CancellationToken.None);
+
+                if (result.IsLeft) {
+                    var error = result.LeftToSeq().FirstOrDefault()!;
+                    logger.Error("Failed to download latest Unchained-Mods", error);
+                    UserDialogueSpawner.DisplayMessage(
+                        "Failed to download latest Unchained-Mods. Aborting launch. Check the logs for more details.");
+                    return false;
+                }
+            }
+
+            return true;
+
+            bool IsUnchainedMods(Release release) => release.Manifest.RepoName == "Unchained-Mods" &&
+                                                     release.Manifest.Organization == "Chiv2-Community";
+        }
+
+        private Either<UnchainedLaunchFailure, Process> InjectDLLs(Process process) {
             IEnumerable<string>? dlls = null;
             try {
                 dlls = FetchDLLs();
@@ -68,9 +192,9 @@ namespace UnchainedLauncher.Core.Processes.Chivalry {
                 Inject.InjectAll(process, dlls);
             }
             catch (Exception e) {
-                return Prelude.Left(ProcessLaunchFailure.InjectionFailed(Optional(dlls), e));
+                return Left(UnchainedLaunchFailure.InjectionFailed(Optional(dlls), e));
             }
-            return Prelude.Right(process);
+            return Right(process);
         }
 
         private static void PrepareModdedLaunchSigs() {

--- a/UnchainedLauncher.Core/Utilities/FileInfoVersionExtractor.cs
+++ b/UnchainedLauncher.Core/Utilities/FileInfoVersionExtractor.cs
@@ -1,0 +1,44 @@
+﻿using log4net;
+using Semver;
+using System.Diagnostics;
+
+namespace UnchainedLauncher.Core.Utilities {
+    
+    public interface IVersionExtractor<T> {
+        
+        /// <summary>
+        /// Provided some target T (like a file path), output the SemVersion of the associated object.
+        /// </summary>
+        /// <param name="input">Some identifier used to locate a versioned resource</param>
+        /// <returns>The version of the target</returns>
+        SemVersion? GetVersion(T input);
+    }
+
+    /// <summary>
+    /// Uses file metadata to extract the SemVersion of the provided file path
+    /// </summary>
+    public class FileInfoVersionExtractor : IVersionExtractor<string> {
+        private readonly ILog logger = LogManager.GetLogger(typeof(FileInfoVersionExtractor));
+
+        public SemVersion? GetVersion(string filePath) {
+            if (!File.Exists(filePath)) return null;
+            
+            var fileInfo = FileVersionInfo.GetVersionInfo(filePath);
+
+            var versionString = fileInfo.ProductVersion ?? fileInfo.FileVersion ?? "";
+            logger.Debug($"Raw file version for '{filePath}': {versionString}");
+            var splitVersionString = versionString.Split('.');
+            versionString = String.Join('.', splitVersionString.Take(3));
+            logger.Debug($"Cleaned file version for '{filePath}': {versionString}");
+
+            try {
+                return SemVersion.Parse(versionString, SemVersionStyles.Any);
+            }
+            catch (Exception e) {
+                logger.Error($"Unable to parse version for '{filePath}': {e.Message}");
+                return null;
+            }
+        }
+    }
+    
+}

--- a/UnchainedLauncher.Core/Utilities/GithubReleaseLocator.cs
+++ b/UnchainedLauncher.Core/Utilities/GithubReleaseLocator.cs
@@ -24,6 +24,11 @@ namespace UnchainedLauncher.Core.Utilities {
     }
     public record ReleaseAsset(string Name, string DownloadUrl);
 
+    /// <summary>
+    /// An IReleaseLocator is used for finding releases for non-mod files.
+    ///
+    /// This means things like the plugin DLL, the launcher itself, or other non-mod files. 
+    /// </summary>
     public interface IReleaseLocator {
         /// <summary>
         /// Returns the latest stable release of the target application.
@@ -38,6 +43,10 @@ namespace UnchainedLauncher.Core.Utilities {
         public Task<IEnumerable<ReleaseTarget>> GetAllReleases();
     }
 
+    /// <summary>
+    /// The GithubReleaseLocator finds all github releases associated with a specified repository and provides targets
+    /// for downloading those releases.
+    /// </summary>
     public class GithubReleaseLocator : IReleaseLocator {
         public static readonly ILog logger = LogManager.GetLogger(nameof(GithubReleaseLocator));
 
@@ -45,15 +54,14 @@ namespace UnchainedLauncher.Core.Utilities {
         private string RepoOwner;
         private string RepoName;
 
-        private IEnumerable<ReleaseTarget>? ReleaseCache { get; set; } = null;
-        private ReleaseTarget? LatestRelease { get; set; } = null;
+        private IEnumerable<ReleaseTarget>? ReleaseCache { get; set; }
+        private ReleaseTarget? LatestRelease { get; set; }
 
         public GithubReleaseLocator(GitHubClient githubClient, string repoOwner, string repoName) {
             GitHubClient = githubClient;
             RepoName = repoName;
             RepoOwner = repoOwner;
         }
-
 
         public async Task<ReleaseTarget?> GetLatestRelease() {
             if (LatestRelease != null) {

--- a/UnchainedLauncher.Core/Utilities/IUpdateNotifier.cs
+++ b/UnchainedLauncher.Core/Utilities/IUpdateNotifier.cs
@@ -1,0 +1,30 @@
+﻿using CommunityToolkit.Mvvm.Input;
+using LanguageExt;
+using System.Diagnostics;
+using System.Windows.Input;
+using UnchainedLauncher.Core.Mods;
+
+namespace UnchainedLauncher.Core.Utilities {
+
+    
+    public interface IUpdateNotifier {
+        public UserDialogueChoice? Notify(string titleText, string messageText, string yesButtonText,
+            string noButtonText, string? cancelButtonText, IEnumerable<DependencyUpdate> updates);
+
+        public UserDialogueChoice? Notify(string titleText, string messageText, string yesButtonText, string noButtonText, string? cancelButtonText, DependencyUpdate firstUpdate, params DependencyUpdate[] updates) {
+            var allUpdates = new List<DependencyUpdate>();
+            allUpdates.Add(firstUpdate);
+            allUpdates.AddRange(updates);
+            
+            return Notify(titleText, messageText, yesButtonText, noButtonText, cancelButtonText, allUpdates);
+        }
+    }
+    
+    public record DependencyUpdate(string Name, Option<string> CurrentVersion, string LatestVersion, string ReleaseUrl, string Reason) {
+        public string CurrentVersionString => CurrentVersion.IfNone("None");
+
+        public static DependencyUpdate FromUpdateCandidate(UpdateCandidate modUpdate) {
+            return new DependencyUpdate(modUpdate.CurrentlyEnabled.Manifest.Name, modUpdate.CurrentlyEnabled.Tag, modUpdate.AvailableUpdate.Tag, modUpdate.AvailableUpdate.ReleaseUrl, "");
+        }
+    };
+}

--- a/UnchainedLauncher.Core/Utilities/IUserDialogueSpawner.cs
+++ b/UnchainedLauncher.Core/Utilities/IUserDialogueSpawner.cs
@@ -1,0 +1,11 @@
+﻿using log4net;
+
+namespace UnchainedLauncher.Core.Utilities {
+    
+    
+    public interface IUserDialogueSpawner {
+        public void DisplayMessage(string message);
+        public UserDialogueChoice DisplayYesNoMessage(string message, string caption);
+    }
+    
+}

--- a/UnchainedLauncher.Core/Utilities/UserDialogueChoice.cs
+++ b/UnchainedLauncher.Core/Utilities/UserDialogueChoice.cs
@@ -1,0 +1,7 @@
+﻿namespace UnchainedLauncher.Core.Utilities {
+    public enum UserDialogueChoice {
+        Yes,
+        No,
+        Cancel
+    }
+}

--- a/UnchainedLauncher.GUI/Utilities/MessageBoxResultExtensions.cs
+++ b/UnchainedLauncher.GUI/Utilities/MessageBoxResultExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System.Windows;
+using UnchainedLauncher.Core.Utilities;
+
+namespace UnchainedLauncher.GUI.Utilities {
+    internal static class MessageBoxResultExtensions {
+        public static UserDialogueChoice ToMessageBoxResult(this MessageBoxResult result) =>
+            result switch {
+                MessageBoxResult.Yes or MessageBoxResult.OK => UserDialogueChoice.Yes,
+                MessageBoxResult.Cancel or MessageBoxResult.None => UserDialogueChoice.Cancel,
+                MessageBoxResult.No => UserDialogueChoice.No,
+            };
+    }
+}

--- a/UnchainedLauncher.GUI/Utilities/MessageBoxSpawner.cs
+++ b/UnchainedLauncher.GUI/Utilities/MessageBoxSpawner.cs
@@ -1,0 +1,10 @@
+﻿using System.Windows;
+using UnchainedLauncher.Core.Utilities;
+
+namespace UnchainedLauncher.GUI.Utilities {
+    public class MessageBoxSpawner: IUserDialogueSpawner {
+        public void DisplayMessage(string message) => MessageBox.Show(message);
+        public UserDialogueChoice DisplayYesNoMessage(string message, string caption) => 
+            MessageBox.Show(message, caption, MessageBoxButton.YesNo).ToMessageBoxResult();
+    }
+}

--- a/UnchainedLauncher.GUI/Utilities/WindowedUpdateNotifier.cs
+++ b/UnchainedLauncher.GUI/Utilities/WindowedUpdateNotifier.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using UnchainedLauncher.Core.Utilities;
+using UnchainedLauncher.GUI.ViewModels;
+using UnchainedLauncher.GUI.Views;
+
+namespace UnchainedLauncher.GUI.Utilities {
+    public class WindowedUpdateNotifier: IUpdateNotifier {
+        public UserDialogueChoice? Notify(string titleText, string messageText, string yesButtonText, string noButtonText,
+            string? cancelButtonText, IEnumerable<DependencyUpdate> updates) {
+            var result = UpdatesWindow.Show(titleText, messageText, yesButtonText, noButtonText, cancelButtonText, 
+                from update in updates 
+                select new DependencyUpdateViewModel(update)
+            );
+
+            return result?.ToMessageBoxResult();
+        }
+    }
+}

--- a/UnchainedLauncher.GUI/ViewModels/SettingsViewModel.cs
+++ b/UnchainedLauncher.GUI/ViewModels/SettingsViewModel.cs
@@ -51,6 +51,8 @@ namespace UnchainedLauncher.GUI.ViewModels {
 
         public ICommand CheckForUpdateCommand { get; }
         public ICommand CleanUpInstallationCommand { get; }
+        private IUpdateNotifier UpdateNotifier { get; }
+        private IUserDialogueSpawner UserDialogueSpawner { get; }
 
         public static IEnumerable<InstallationType> AllInstallationTypes {
             get { return Enum.GetValues(typeof(InstallationType)).Cast<InstallationType>(); }
@@ -62,9 +64,11 @@ namespace UnchainedLauncher.GUI.ViewModels {
         public readonly Action<int> ExitProgram;
         public bool CanClick { get; set; }
 
-        public SettingsViewModel(IUnchainedLauncherInstaller installer, IReleaseLocator unchainedReleaseLocator, InstallationType installationType, bool enablePluginAutomaticUpdates, string additionalModActors, string serverBrowserBackend, FileBackedSettings<LauncherSettings> launcherSettings, string cliArgs, Action<int> exitProgram) {
+        public SettingsViewModel(IUnchainedLauncherInstaller installer, IReleaseLocator unchainedReleaseLocator, IUpdateNotifier updateNotifier, IUserDialogueSpawner dialogueSpawner, InstallationType installationType, bool enablePluginAutomaticUpdates, string additionalModActors, string serverBrowserBackend, FileBackedSettings<LauncherSettings> launcherSettings, string cliArgs, Action<int> exitProgram) {
             Installer = installer;
             UnchainedReleaseLocator = unchainedReleaseLocator;
+            UpdateNotifier = updateNotifier;
+            UserDialogueSpawner = dialogueSpawner;
             InstallationType = installationType;
             EnablePluginAutomaticUpdates = enablePluginAutomaticUpdates;
             AdditionalModActors = additionalModActors;
@@ -81,7 +85,7 @@ namespace UnchainedLauncher.GUI.ViewModels {
         }
 
 
-        public static SettingsViewModel LoadSettings(IChivalry2InstallationFinder installationFinder, IUnchainedLauncherInstaller installer, IReleaseLocator unchainedReleaseLocator, Action<int> exitProgram) {
+        public static SettingsViewModel LoadSettings(IChivalry2InstallationFinder installationFinder, IUnchainedLauncherInstaller installer, IReleaseLocator unchainedReleaseLocator, IUpdateNotifier updateNotifier, IUserDialogueSpawner userDialogueSpawner, Action<int> exitProgram) {
             var cliArgsList = Environment.GetCommandLineArgs();
             var cliArgs = cliArgsList.Length > 1 ? Environment.GetCommandLineArgs().Skip(1).Aggregate((x, y) => $"{x} {y}") : "";
 
@@ -91,6 +95,8 @@ namespace UnchainedLauncher.GUI.ViewModels {
             return new SettingsViewModel(
                 installer,
                 unchainedReleaseLocator,
+                updateNotifier,
+                userDialogueSpawner,
                 loadedSettings?.InstallationType ?? DetectInstallationType(installationFinder),
                 loadedSettings?.EnablePluginAutomaticUpdates ?? true,
                 loadedSettings?.AdditionalModActors ?? "",
@@ -123,10 +129,10 @@ namespace UnchainedLauncher.GUI.ViewModels {
                 "After deleting, the launcher will restart itself."
             }.Aggregate((accumulator, next) => accumulator + "\n" + next);
 
-            var choice = MessageBox.Show(message, "Really clean up installation?", MessageBoxButton.YesNo);
+            var choice = UserDialogueSpawner.DisplayYesNoMessage(message, "Really clean up installation?");
             logger.Info($"Are you sure? User selects: {choice}");
 
-            if (choice == MessageBoxResult.No) return;
+            if (choice == UserDialogueChoice.No) return;
 
             FileHelpers.DeleteDirectory(FilePaths.ModCachePath);
             FileHelpers.DeleteDirectory(FilePaths.PluginDir);
@@ -162,7 +168,7 @@ namespace UnchainedLauncher.GUI.ViewModels {
             };
 
             PowerShell.Run(powershellCommands);
-            MessageBox.Show("The launcher will now restart. No further action must be taken.");
+            UserDialogueSpawner.DisplayMessage("The launcher will now restart. No further action must be taken.");
 
             logger.Info("Closing");
             ExitProgram(0);
@@ -174,7 +180,7 @@ namespace UnchainedLauncher.GUI.ViewModels {
 
             var latestRelease = await UnchainedReleaseLocator.GetLatestRelease();
             if (latestRelease == null) {
-                MessageBox.Show("Failed to check for updates. Check the logs for more details.");
+                UserDialogueSpawner.DisplayMessage("Failed to check for updates. Check the logs for more details.");
                 return;
             }
 
@@ -183,30 +189,27 @@ namespace UnchainedLauncher.GUI.ViewModels {
                 await ChangeVersion(latestRelease);
             }
             else {
-                MessageBox.Show("You are currently running the latest version.");
-                return;
+                UserDialogueSpawner.DisplayMessage("You are currently running the latest version.");
             }
         }
 
         private async Task ChangeVersion(ReleaseTarget release) {
-            Option<MessageBoxResult> dialogResult =
-                UpdatesWindow.Show(
+            UserDialogueChoice? dialogResult =
+                UpdateNotifier.Notify(
                     "Chivalry 2 Unchained Launcher Update",
                     "Update the Unchained Launcher?",
                     "Yes",
                     "No",
                     null,
-                    List(
-                        new DependencyUpdate("Launcher", Some(CurrentVersion.ToString()), release.Version.ToString(), release.PageUrl, "")
-                    )
+                    new DependencyUpdate("Launcher", Some(CurrentVersion), release.Version.ToString(), release.PageUrl, "")
                 );
 
-            if (dialogResult.Contains(MessageBoxResult.No)) {
+            if (dialogResult == UserDialogueChoice.No) {
                 logger.Info("User chose not to update.");
                 return;
             }
 
-            if (dialogResult.Contains(MessageBoxResult.Yes)) {
+            if (dialogResult == UserDialogueChoice.Yes) {
                 logger.Info("User chose to update.");
                 await Installer.Install(new DirectoryInfo(Environment.CurrentDirectory), release, true, (_) => { });
             }
@@ -220,14 +223,12 @@ namespace UnchainedLauncher.GUI.ViewModels {
         private static InstallationType DetectInstallationType(IChivalry2InstallationFinder finder) {
             var curDir = new DirectoryInfo(Directory.GetCurrentDirectory());
 
-            if (finder.IsEGSDir(curDir))
-                return InstallationType.EpicGamesStore;
-            else if (finder.IsSteamDir(curDir))
-                return InstallationType.Steam;
-            else {
-                logger.Warn("Could not detect installation type.");
-                return InstallationType.NotSet;
-            }
+            if (finder.IsEGSDir(curDir)) return InstallationType.EpicGamesStore;
+            
+            if (finder.IsSteamDir(curDir)) return InstallationType.Steam;
+            
+            logger.Warn("Could not detect installation type.");
+            return InstallationType.NotSet;
         }
     }
 

--- a/UnchainedLauncher.GUI/ViewModels/UpdatesWindowViewModel.cs
+++ b/UnchainedLauncher.GUI/ViewModels/UpdatesWindowViewModel.cs
@@ -4,9 +4,11 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Linq;
 using System.Windows;
 using System.Windows.Input;
 using UnchainedLauncher.Core.Mods;
+using UnchainedLauncher.Core.Utilities;
 
 namespace UnchainedLauncher.GUI.ViewModels {
     public partial class UpdatesWindowViewModel : INotifyPropertyChanged {
@@ -19,7 +21,7 @@ namespace UnchainedLauncher.GUI.ViewModels {
         public string CancelColumnWidth => ShowCancelButton ? "40*" : "0";
         public string NoButtonMargin => ShowCancelButton ? "5,10,0,10" : "5,10,10,10";
 
-        public IEnumerable<DependencyUpdate> Updates { get; }
+        public IEnumerable<DependencyUpdateViewModel> Updates { get; }
 
         public MessageBoxResult Result { get; private set; }
 
@@ -28,9 +30,7 @@ namespace UnchainedLauncher.GUI.ViewModels {
         public ICommand CancelCommand { get; set; }
         private Action CloseWindow { get; }
 
-        public UpdatesWindowViewModel() : this("Title", "Message", "Yes", "No", null, new List<DependencyUpdate>(), () => { }) { }
-
-        public UpdatesWindowViewModel(string titleText, string messageText, string yesButtonText, string noButtonText, string? cancelButtonText, IEnumerable<DependencyUpdate> updates, Action closeWindow) {
+        public UpdatesWindowViewModel(string titleText, string messageText, string yesButtonText, string noButtonText, string? cancelButtonText, IEnumerable<DependencyUpdateViewModel> updates, Action closeWindow) {
             TitleText = titleText;
             MessageText = messageText;
             YesButtonText = yesButtonText;
@@ -66,17 +66,13 @@ namespace UnchainedLauncher.GUI.ViewModels {
 
     }
 
-    public record DependencyUpdate(string Name, Option<string> CurrentVersion, string LatestVersion, string ReleaseUrl, string Reason) {
-        public string CurrentVersionString => CurrentVersion.IfNone("None");
-        public string VersionString => CurrentVersion == null ? LatestVersion : $"{CurrentVersionString} -> {LatestVersion}";
+    public record DependencyUpdateViewModel(DependencyUpdate Update) {
+        public string CurrentVersionString => Update.CurrentVersion.IfNone("None");
+        public string VersionString => Update.CurrentVersion == null ? Update.LatestVersion : $"{CurrentVersionString} -> {Update.LatestVersion}";
         public ICommand HyperlinkCommand => new RelayCommand(Hyperlink_Click);
 
         public void Hyperlink_Click() {
-            Process.Start(new ProcessStartInfo { FileName = ReleaseUrl, UseShellExecute = true });
-        }
-
-        public static DependencyUpdate FromUpdateCandidate(UpdateCandidate modUpdate) {
-            return new DependencyUpdate(modUpdate.CurrentlyEnabled.Manifest.Name, modUpdate.CurrentlyEnabled.Tag, modUpdate.AvailableUpdate.Tag, modUpdate.AvailableUpdate.ReleaseUrl, "");
+            Process.Start(new ProcessStartInfo { FileName = Update.ReleaseUrl, UseShellExecute = true });
         }
     };
 

--- a/UnchainedLauncher.GUI/Views/DesignInstances/LauncherViewModelInstances.cs
+++ b/UnchainedLauncher.GUI/Views/DesignInstances/LauncherViewModelInstances.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using UnchainedLauncher.Core.JsonModels.Metadata.V3;
 using UnchainedLauncher.Core.Mods;
 using UnchainedLauncher.Core.Mods.Registry;
+using UnchainedLauncher.Core.Utilities;
+using UnchainedLauncher.GUI.Utilities;
 using UnchainedLauncher.GUI.ViewModels;
 
 namespace UnchainedLauncher.GUI.Views.DesignInstances {
@@ -11,7 +13,7 @@ namespace UnchainedLauncher.GUI.Views.DesignInstances {
             SettingsViewModelInstances.DEFAULT,
             new ModManager(new HashMap<IModRegistry, IEnumerable<Mod>>(), new List<Release>()),
             null, null, null,
-            null
+            null, new FileInfoVersionExtractor(), new MessageBoxSpawner()
         );
     }
 }

--- a/UnchainedLauncher.GUI/Views/DesignInstances/ModListViewModelInstances.cs
+++ b/UnchainedLauncher.GUI/Views/DesignInstances/ModListViewModelInstances.cs
@@ -4,6 +4,7 @@ using UnchainedLauncher.Core.JsonModels.Metadata.V3;
 using UnchainedLauncher.Core.Mods;
 using UnchainedLauncher.Core.Mods.Registry;
 using UnchainedLauncher.Core.Mods.Registry.Downloader;
+using UnchainedLauncher.GUI.Utilities;
 using UnchainedLauncher.GUI.ViewModels;
 
 namespace UnchainedLauncher.GUI.Views.DesignInstances {
@@ -17,7 +18,9 @@ namespace UnchainedLauncher.GUI.Views.DesignInstances {
                         { new LocalModRegistry("", new LocalFilePakDownloader("")), new List<Mod> { ModViewModelInstances.DesignViewMod } }
                     },
                     new List<Release> { ModViewModelInstances.DesignViewRelease }
-                )
+                ),
+                new WindowedUpdateNotifier(),
+                new MessageBoxSpawner()
             );
 
             instance.SelectedMod = ModViewModelInstances.DEFAULT;

--- a/UnchainedLauncher.GUI/Views/DesignInstances/ServerLauncherViewModelInstances.cs
+++ b/UnchainedLauncher.GUI/Views/DesignInstances/ServerLauncherViewModelInstances.cs
@@ -4,6 +4,7 @@ using UnchainedLauncher.Core.JsonModels.Metadata.V3;
 using UnchainedLauncher.Core.Mods;
 using UnchainedLauncher.Core.Mods.Registry;
 using UnchainedLauncher.GUI.JsonModels;
+using UnchainedLauncher.GUI.Utilities;
 using UnchainedLauncher.GUI.ViewModels;
 
 namespace UnchainedLauncher.GUI.Views.DesignInstances {
@@ -13,6 +14,7 @@ namespace UnchainedLauncher.GUI.Views.DesignInstances {
             ServersViewModelInstances.DEFAULT,
             null,
             new ModManager(new HashMap<IModRegistry, IEnumerable<Mod>>(), new List<Release>()),
+            new MessageBoxSpawner(),
             "Chivalry 2 server",
             "Design time test description",
             "",

--- a/UnchainedLauncher.GUI/Views/DesignInstances/SettingsViewModelInstances.cs
+++ b/UnchainedLauncher.GUI/Views/DesignInstances/SettingsViewModelInstances.cs
@@ -1,6 +1,7 @@
 ﻿using UnchainedLauncher.Core.Installer;
 using UnchainedLauncher.Core.JsonModels;
 using UnchainedLauncher.GUI.JsonModels;
+using UnchainedLauncher.GUI.Utilities;
 using UnchainedLauncher.GUI.ViewModels;
 
 namespace UnchainedLauncher.GUI.Views.DesignInstances {
@@ -8,6 +9,8 @@ namespace UnchainedLauncher.GUI.Views.DesignInstances {
         public static SettingsViewModel DEFAULT => new SettingsViewModel(
             new MockInstaller(),
             null,
+            new WindowedUpdateNotifier(),
+            new MessageBoxSpawner(),
             InstallationType.Steam,
             true,
             "--design-time-only-default-constructor",

--- a/UnchainedLauncher.GUI/Views/UpdatesWindow.xaml
+++ b/UnchainedLauncher.GUI/Views/UpdatesWindow.xaml
@@ -46,16 +46,16 @@
                 <DataTemplate>
                     <StackPanel Orientation="Vertical">
                         <StackPanel Orientation="Horizontal" Margin="5,5,5,0">
-                            <TextBlock Text="{Binding Name}" />
+                            <TextBlock Text="{Binding Update.Name}" />
                             <TextBlock Text=": " />
-                            <TextBlock Text="{Binding Reason}" />
+                            <TextBlock Text="{Binding Update.Reason}" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Margin="5,0,5,5" >
                             <TextBlock Text="Version: " />
                             <TextBlock Text="{Binding VersionString}" />
                             <TextBlock Text=" " />
                             <TextBlock>
-                                    <Hyperlink NavigateUri="{Binding ReleaseUrl}" Command="{Binding HyperlinkCommand}">
+                                    <Hyperlink NavigateUri="{Binding Update.ReleaseUrl}" Command="{Binding HyperlinkCommand}">
                                         View Release Information
                                     </Hyperlink>
                             </TextBlock>

--- a/UnchainedLauncher.GUI/Views/UpdatesWindow.xaml.cs
+++ b/UnchainedLauncher.GUI/Views/UpdatesWindow.xaml.cs
@@ -4,6 +4,7 @@ using log4net;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
+using UnchainedLauncher.Core.Utilities;
 using UnchainedLauncher.GUI.ViewModels;
 
 namespace UnchainedLauncher.GUI.Views {
@@ -17,22 +18,21 @@ namespace UnchainedLauncher.GUI.Views {
         private static readonly ILog logger = LogManager.GetLogger(nameof(SettingsViewModel));
 
         public UpdatesWindowViewModel ViewModel { get; private set; }
-        public MessageBoxResult Result => ViewModel.Result;
 
-        public UpdatesWindow(string titleText, string messageText, string yesButtonText, string noButtonText, string? cancelButtonText, IEnumerable<DependencyUpdate> updates) {
+        public UpdatesWindow(string titleText, string messageText, string yesButtonText, string noButtonText, string? cancelButtonText, IEnumerable<DependencyUpdateViewModel> updates) {
             ViewModel = new UpdatesWindowViewModel(titleText, messageText, yesButtonText, noButtonText, cancelButtonText, updates, Close);
             DataContext = ViewModel;
             InitializeComponent();
         }
 
-        public static Option<MessageBoxResult> Show(string titleText, string messageText, string yesButtonText, string noButtonText, string? cancelButtonText, IEnumerable<DependencyUpdate> updates) {
+        public static MessageBoxResult? Show(string titleText, string messageText, string yesButtonText, string noButtonText, string? cancelButtonText, IEnumerable<DependencyUpdateViewModel> updates) {
             if (!updates.Any()) {
                 logger.Info("No updates available");
-                return None;
+                return null;
             }
 
             var message = $"Found {updates.Count()} updates available.\n\n";
-            message += string.Join("\n", updates.Select(x => $"- {x.Name} {x.CurrentVersion} -> {x.LatestVersion}"));
+            message += string.Join("\n", updates.Select(x => $"- {x.Update.Name} {x.Update.CurrentVersion} -> {x.Update.LatestVersion}"));
             message.Split("\n").ToList().ForEach(x => logger.Info(x));
 
             var window = new UpdatesWindow(titleText, messageText, yesButtonText, noButtonText, cancelButtonText, updates);
@@ -40,11 +40,11 @@ namespace UnchainedLauncher.GUI.Views {
 
             MessageBoxResult result = window.ViewModel.Result;
             logger.Info("User Selects: " + result);
-            return Some(result);
+            return result;
         }
 
-        public static MessageBoxResult Show(string titleText, string messageText, string yesButtonText, string noButtonText, string? cancelButtonText, DependencyUpdate update) {
-            return Show(titleText, messageText, yesButtonText, noButtonText, cancelButtonText, new[] { update }).ValueUnsafe();
+        public static MessageBoxResult? Show(string titleText, string messageText, string yesButtonText, string noButtonText, string? cancelButtonText, params DependencyUpdateViewModel[] updates) {
+            return Show(titleText, messageText, yesButtonText, noButtonText, cancelButtonText, updates.AsEnumerable());
         }
     }
 }


### PR DESCRIPTION
All use-cases for the launcher class involve setting up mods and dlls, so I moved that in to the launcher. Doing so required factoring out interfaces for message boxes and update notifications, which is where the majority of the changes here come from.