### PR TITLE
registry-control-UI

### DIFF
--- a/UnchainedLauncher.Core/Services/Mods/Registry/AggregateModRegistry.cs
+++ b/UnchainedLauncher.Core/Services/Mods/Registry/AggregateModRegistry.cs
@@ -14,10 +14,10 @@ namespace UnchainedLauncher.Core.Services.Mods.Registry {
             "AggregateModRegistry of: \n\t" +
                 string.Join("\n\t", ModRegistries.Select(m => m.Name));
 
-        public IOrderedEnumerable<IModRegistry> ModRegistries { get; }
+        public IList<IModRegistry> ModRegistries { get; }
 
         public AggregateModRegistry(IEnumerable<IModRegistry> modRegistries) {
-            ModRegistries = modRegistries.OrderBy(m => m.Name);
+            ModRegistries = modRegistries.OrderBy(m => m.Name).ToList();
         }
 
         public AggregateModRegistry(params IModRegistry[] registries) : this(registries.ToList()) { }

--- a/UnchainedLauncher.Core/Services/Mods/Registry/Downloader/LocalFilePakDownloader.cs
+++ b/UnchainedLauncher.Core/Services/Mods/Registry/Downloader/LocalFilePakDownloader.cs
@@ -4,7 +4,7 @@ using UnchainedLauncher.Core.JsonModels.Metadata.V3;
 
 namespace UnchainedLauncher.Core.Services.Mods.Registry.Downloader {
     public class LocalFilePakDownloader : IModRegistryDownloader {
-        public string PakReleasesDir { get; }
+        public string PakReleasesDir { get; set; }
 
         public LocalFilePakDownloader(string pakReleasesDir) {
             PakReleasesDir = pakReleasesDir;

--- a/UnchainedLauncher.Core/Services/Mods/Registry/GithubModRegistry.cs
+++ b/UnchainedLauncher.Core/Services/Mods/Registry/GithubModRegistry.cs
@@ -12,8 +12,8 @@ namespace UnchainedLauncher.Core.Services.Mods.Registry {
 
         public override string Name => $"Github mod registry at {Organization}/{RepoName}";
         public IModRegistryDownloader ModRegistryDownloader { get; }
-        public string Organization { get; }
-        public string RepoName { get; }
+        public string Organization { get; set; }
+        public string RepoName { get; set; }
         public string PackageDBBaseUrl => $"https://raw.githubusercontent.com/{Organization}/{RepoName}/db/package_db";
         public string PackageDBPackageListUrl => $"{PackageDBBaseUrl}/mod_list_index.txt";
 

--- a/UnchainedLauncher.Core/Services/Mods/Registry/LocalModRegistry.cs
+++ b/UnchainedLauncher.Core/Services/Mods/Registry/LocalModRegistry.cs
@@ -10,7 +10,7 @@ namespace UnchainedLauncher.Core.Services.Mods.Registry {
     public class LocalModRegistry : JsonRegistry {
         public override string Name => $"Local filesystem registry at {RegistryPath}";
         public IModRegistryDownloader ModRegistryDownloader { get; }
-        public string RegistryPath { get; }
+        public string RegistryPath { get; set; }
         public LocalModRegistry(string registryPath, IModRegistryDownloader downloader) {
             RegistryPath = registryPath;
             ModRegistryDownloader = downloader;

--- a/UnchainedLauncher.GUI/App.xaml.cs
+++ b/UnchainedLauncher.GUI/App.xaml.cs
@@ -20,6 +20,7 @@ using UnchainedLauncher.Core.Utilities;
 using UnchainedLauncher.GUI.Services;
 using UnchainedLauncher.GUI.ViewModels;
 using UnchainedLauncher.GUI.ViewModels.Installer;
+using UnchainedLauncher.GUI.ViewModels.Registry;
 using UnchainedLauncher.GUI.ViewModels.ServersTab;
 using UnchainedLauncher.GUI.Views;
 using UnchainedLauncher.GUI.Views.Installer;
@@ -108,8 +109,17 @@ namespace UnchainedLauncher.GUI {
 
             var settingsViewModel = SettingsVM.LoadSettings(installationFinder, installer, launcherReleaseLocator, userDialogueSpawner, Environment.Exit);
 
+            var registryTabViewModel = new RegistryTabVM();
+            // TODO: do load/save instead of always adding this manually
+            registryTabViewModel.AddRegistry(
+                new GithubModRegistry(
+                    "Chiv2-Community",
+                    "C2ModRegistry",
+                    HttpPakDownloader.GithubPakDownloader)
+                );
+
             var modManager = new ModManager(
-                new GithubModRegistry("Chiv2-Community", "C2ModRegistry", HttpPakDownloader.GithubPakDownloader),
+                registryTabViewModel.Registry,
                 new List<ReleaseCoordinates>() // TODO: Load this from somewhere, or something. 
             );
 
@@ -190,7 +200,8 @@ namespace UnchainedLauncher.GUI {
                 launcherViewModel,
                 modListViewModel,
                 settingsViewModel,
-                serversTabViewModel
+                serversTabViewModel,
+                registryTabViewModel
             );
 
             return new MainWindow(mainWindowViewModel);

--- a/UnchainedLauncher.GUI/ViewModels/MainWindowVM.cs
+++ b/UnchainedLauncher.GUI/ViewModels/MainWindowVM.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.ComponentModel;
+using UnchainedLauncher.GUI.ViewModels.Registry;
 using UnchainedLauncher.GUI.ViewModels.ServersTab;
 
 namespace UnchainedLauncher.GUI.ViewModels {
     public partial class MainWindowVM : INotifyPropertyChanged, IDisposable {
         public LauncherVM LauncherViewModel { get; }
+        public RegistryTabVM RegistryTabViewModel { get; }
         public ModListVM ModListViewModel { get; }
         public SettingsVM SettingsViewModel { get; }
         public ServersTabVM ServersTab { get; }
@@ -17,6 +19,7 @@ namespace UnchainedLauncher.GUI.ViewModels {
             ModListViewModel = modListViewModel;
             SettingsViewModel = settingsViewModel;
             ServersTab = serversTab;
+            RegistryTabViewModel = RegistryTabVM.DEFAULT;
         }
 
         public void Dispose() {

--- a/UnchainedLauncher.GUI/ViewModels/MainWindowVM.cs
+++ b/UnchainedLauncher.GUI/ViewModels/MainWindowVM.cs
@@ -14,12 +14,13 @@ namespace UnchainedLauncher.GUI.ViewModels {
         public MainWindowVM(LauncherVM launcherViewModel,
                             ModListVM modListViewModel,
                             SettingsVM settingsViewModel,
-                            ServersTabVM serversTab) {
+                            ServersTabVM serversTab,
+                            RegistryTabVM registryTabViewModel) {
             LauncherViewModel = launcherViewModel;
             ModListViewModel = modListViewModel;
             SettingsViewModel = settingsViewModel;
             ServersTab = serversTab;
-            RegistryTabViewModel = RegistryTabVM.DEFAULT;
+            RegistryTabViewModel = registryTabViewModel;
         }
 
         public void Dispose() {

--- a/UnchainedLauncher.GUI/ViewModels/Registry/RegistryTabVM.cs
+++ b/UnchainedLauncher.GUI/ViewModels/Registry/RegistryTabVM.cs
@@ -1,0 +1,95 @@
+using PropertyChanged;
+using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using UnchainedLauncher.Core.Services.Mods.Registry;
+using UnchainedLauncher.Core.Services.Mods.Registry.Downloader;
+
+namespace UnchainedLauncher.GUI.ViewModels.Registry {
+    public partial class RegistryTabVM {
+        public AggregateModRegistry Registry { get; private set; }
+        public ObservableCollection<IModRegistryVM> Registries { get; }
+        public RegistryTabVM(AggregateModRegistry registry) {
+            Registry = registry;
+            Registries = new ObservableCollection<IModRegistryVM>();
+            pullRegistryVMs();
+        }
+
+        public void pullRegistryVMs() {
+            Registries.Clear();
+            foreach (IModRegistryVM vm in Registry.ModRegistries.Map(IntoVM)) {
+                Registries.Add(vm);
+            }
+        }
+
+        public static IModRegistryVM IntoVM(IModRegistry registry) {
+            if (registry is GithubModRegistry reg) {
+                return new GithubModRegistryVM(reg);
+            }
+            
+            return new GenericModRegistryVM(registry);
+        }
+        
+        public RegistryTabVM() : this(new AggregateModRegistry()) {}
+        
+        public static RegistryTabVM DEFAULT => makeDefault();
+    
+        private static RegistryTabVM makeDefault() {
+            var vm = new RegistryTabVM();
+            vm.Registries.Add(
+                new GithubModRegistryVM(
+                    new GithubModRegistry(
+                        "Chiv2-Community", 
+                        "C2ModRegistry", 
+                        new HttpPakDownloader($"https://github.com/<Org>/<Repo>/releases/download/<Version>/<PakFileName>"))
+                    )
+                );
+            vm.Registries.Add(
+                new GenericModRegistryVM(
+                    new LocalModRegistry(
+                        "LocalModRegistryTesting1",
+                        new LocalFilePakDownloader("LocalModRegistryTesting1"))
+                )
+            );
+            vm.Registries.Add(
+                new GenericModRegistryVM(
+                    new LocalModRegistry(
+                        "LocalModRegistryTesting2",
+                        new LocalFilePakDownloader("LocalModRegistryTesting2"))
+                )
+            );
+            return vm;
+        }
+    }
+
+    public interface IModRegistryVM {
+        public IModRegistry Registry { get; }
+    }
+    
+    public class GenericModRegistryVM : IModRegistryVM {
+        public IModRegistry Registry { get; }
+
+        public GenericModRegistryVM(IModRegistry registry) {
+            Registry = registry;
+        }
+    }
+
+    [AddINotifyPropertyChangedInterface]
+    public partial class GithubModRegistryVM : INotifyPropertyChanged, IModRegistryVM {
+        public GithubModRegistry _registry { get; private set; }
+        public IModRegistry Registry => _registry;
+
+        public GithubModRegistryVM(GithubModRegistry registry) {
+            _registry = registry;
+        }
+
+        public string Org {
+            get => _registry.Organization;
+            set => _registry.Organization = value;
+        }
+        public string RepoName {
+            get => _registry.RepoName;
+            set => _registry.RepoName = value;
+        }
+    }
+}

--- a/UnchainedLauncher.GUI/ViewModels/Registry/RegistryTabVM.cs
+++ b/UnchainedLauncher.GUI/ViewModels/Registry/RegistryTabVM.cs
@@ -1,3 +1,4 @@
+using CommunityToolkit.Mvvm.Input;
 using Microsoft.VisualBasic.FileIO;
 using PropertyChanged;
 using System;
@@ -24,12 +25,40 @@ namespace UnchainedLauncher.GUI.ViewModels.Registry {
             }
         }
 
-        public static IModRegistryVM IntoVM(IModRegistry registry) {
+        public IModRegistryVM IntoVM(IModRegistry registry) {
             return registry switch {
-                GithubModRegistry reg => new GithubModRegistryVM(reg),
-                LocalModRegistry reg => new LocalModRegistryVM(reg),
+                GithubModRegistry reg => new GithubModRegistryVM(reg, RemoveRegistry),
+                LocalModRegistry reg => new LocalModRegistryVM(reg, RemoveRegistry),
                 _ => new GenericModRegistryVM(registry)
             };
+        }
+
+        [RelayCommand]
+        public void AddNewGithubRegistry() {
+            GithubModRegistry ghr = new GithubModRegistry(
+                "Chiv2-Community",
+                "C2ModRegistry",
+                HttpPakDownloader.GithubPakDownloader
+            );
+            
+            AddRegistry(ghr);
+        }
+
+        [RelayCommand]
+        public void AddNewLocalRegistry() {
+            LocalModRegistry lmr = new LocalModRegistry("LocalRegistryPath", new LocalFilePakDownloader("LocalRegistryPath"));
+            
+            AddRegistry(lmr);
+        }
+        
+        public void AddRegistry(IModRegistry mr) {
+            Registry.ModRegistries.Add(mr);
+            Registries.Add(IntoVM(mr));
+        }
+        
+        public void RemoveRegistry(IModRegistryVM vm) {
+            Registry.ModRegistries.Remove(vm.Registry);
+            Registries.Remove(vm);
         }
         
         public RegistryTabVM() : this(new AggregateModRegistry()) {}
@@ -41,23 +70,26 @@ namespace UnchainedLauncher.GUI.ViewModels.Registry {
             vm.Registries.Add(
                 new GithubModRegistryVM(
                     new GithubModRegistry(
-                        "Chiv2-Community", 
-                        "C2ModRegistry", 
-                        new HttpPakDownloader($"https://github.com/<Org>/<Repo>/releases/download/<Version>/<PakFileName>"))
+                            "Chiv2-Community", 
+                            "C2ModRegistry", 
+                            HttpPakDownloader.GithubPakDownloader
+                        ), vm.RemoveRegistry
                     )
                 );
             vm.Registries.Add(
                 new LocalModRegistryVM(
                     new LocalModRegistry(
                         "LocalModRegistryTesting1",
-                        new LocalFilePakDownloader("LocalModRegistryTesting1"))
+                        new LocalFilePakDownloader("LocalModRegistryTesting1")
+                        ), vm.RemoveRegistry
                 )
             );
             vm.Registries.Add(
                 new LocalModRegistryVM(
                     new LocalModRegistry(
                         "LocalModRegistryTesting2",
-                        new LocalFilePakDownloader("LocalModRegistryTesting2"))
+                        new LocalFilePakDownloader("LocalModRegistryTesting2")
+                    ), vm.RemoveRegistry
                 )
             );
             return vm;
@@ -68,58 +100,65 @@ namespace UnchainedLauncher.GUI.ViewModels.Registry {
         public IModRegistry Registry { get; }
     }
     
-    public class GenericModRegistryVM : IModRegistryVM {
+    [AddINotifyPropertyChangedInterface]
+    public partial class GenericModRegistryVM : INotifyPropertyChanged, IModRegistryVM {
         public IModRegistry Registry { get; }
+        public delegate void RequestDeletion(IModRegistryVM toDelete);
+        private RequestDeletion? _requestDeletion;
+    
+        [RelayCommand]
+        public void SelfDelete() {
+            _requestDeletion?.Invoke(this);
+        }
 
-        public GenericModRegistryVM(IModRegistry registry) {
+        public GenericModRegistryVM(IModRegistry registry, RequestDeletion? requestDeletion = null) {
             Registry = registry;
+            _requestDeletion = requestDeletion;
         }
     }
 
     [AddINotifyPropertyChangedInterface]
-    public partial class GithubModRegistryVM : INotifyPropertyChanged, IModRegistryVM {
-        public GithubModRegistry _registry { get; private set; }
-        public IModRegistry Registry => _registry;
+    public partial class GithubModRegistryVM : GenericModRegistryVM {
+        public new GithubModRegistry Registry { get; private set; }
 
-        public GithubModRegistryVM(GithubModRegistry registry) {
-            _registry = registry;
+        public GithubModRegistryVM(GithubModRegistry registry, RequestDeletion? requestDeletion = null) : base(registry, requestDeletion) {
+            Registry = registry;
         }
         
         [DependsOn(nameof(Org), nameof(RepoName))]
-        public string Name => _registry.Name;
+        public string Name => Registry.Name;
 
         public string Org {
-            get => _registry.Organization;
-            set => _registry.Organization = value;
+            get => Registry.Organization;
+            set => Registry.Organization = value;
         }
         public string RepoName {
-            get => _registry.RepoName;
-            set => _registry.RepoName = value;
+            get => Registry.RepoName;
+            set => Registry.RepoName = value;
         }
     }
     
     [AddINotifyPropertyChangedInterface]
-    public partial class LocalModRegistryVM : INotifyPropertyChanged, IModRegistryVM {
-        public LocalModRegistry _registry { get; private set; }
-        public IModRegistry Registry => _registry;
+    public partial class LocalModRegistryVM : GenericModRegistryVM {
+        public new LocalModRegistry Registry { get; private set; }
 
-        public LocalModRegistryVM(LocalModRegistry registry) {
-            _registry = registry;
+        public LocalModRegistryVM(LocalModRegistry registry, RequestDeletion? requestDeletion = null) : base(registry, requestDeletion) {
+            Registry = registry;
         }
         
         [DependsOn(nameof(RegistryPath))]
-        public string Name => _registry.Name;
+        public string Name => Registry.Name;
 
         public string RegistryPath {
-            get => _registry.RegistryPath;
+            get => Registry.RegistryPath;
             set {
-                _registry.RegistryPath = value;
-                if (_registry.ModRegistryDownloader is LocalFilePakDownloader downloader) {
+                Registry.RegistryPath = value;
+                if (Registry.ModRegistryDownloader is LocalFilePakDownloader downloader) {
                     downloader.PakReleasesDir = value;
                 }
                 else {
                     throw new InvalidOperationException(
-                        $"Unsure how to mutate downloader of type '{_registry.ModRegistryDownloader.GetType().Name}' to use new pak dir"
+                        $"Unsure how to mutate downloader of type '{Registry.ModRegistryDownloader.GetType().Name}' to use new pak dir"
                         );
                 }
             } 

--- a/UnchainedLauncher.GUI/ViewModels/Registry/RegistryTabVM.cs
+++ b/UnchainedLauncher.GUI/ViewModels/Registry/RegistryTabVM.cs
@@ -40,38 +40,38 @@ namespace UnchainedLauncher.GUI.ViewModels.Registry {
                 "C2ModRegistry",
                 HttpPakDownloader.GithubPakDownloader
             );
-            
+
             AddRegistry(ghr);
         }
 
         [RelayCommand]
         public void AddNewLocalRegistry() {
             LocalModRegistry lmr = new LocalModRegistry("LocalRegistryPath", new LocalFilePakDownloader("LocalRegistryPath"));
-            
+
             AddRegistry(lmr);
         }
-        
+
         public void AddRegistry(IModRegistry mr) {
             Registry.ModRegistries.Add(mr);
             Registries.Add(IntoVM(mr));
         }
-        
+
         public void RemoveRegistry(IModRegistryVM vm) {
             Registry.ModRegistries.Remove(vm.Registry);
             Registries.Remove(vm);
         }
-        
-        public RegistryTabVM() : this(new AggregateModRegistry()) {}
-        
+
+        public RegistryTabVM() : this(new AggregateModRegistry()) { }
+
         public static RegistryTabVM DEFAULT => makeDefault();
-    
+
         private static RegistryTabVM makeDefault() {
             var vm = new RegistryTabVM();
             vm.Registries.Add(
                 new GithubModRegistryVM(
                     new GithubModRegistry(
-                            "Chiv2-Community", 
-                            "C2ModRegistry", 
+                            "Chiv2-Community",
+                            "C2ModRegistry",
                             HttpPakDownloader.GithubPakDownloader
                         ), vm.RemoveRegistry
                     )
@@ -99,13 +99,13 @@ namespace UnchainedLauncher.GUI.ViewModels.Registry {
     public interface IModRegistryVM {
         public IModRegistry Registry { get; }
     }
-    
+
     [AddINotifyPropertyChangedInterface]
     public partial class GenericModRegistryVM : INotifyPropertyChanged, IModRegistryVM {
         public IModRegistry Registry { get; }
         public delegate void RequestDeletion(IModRegistryVM toDelete);
         private RequestDeletion? _requestDeletion;
-    
+
         [RelayCommand]
         public void SelfDelete() {
             _requestDeletion?.Invoke(this);
@@ -124,7 +124,7 @@ namespace UnchainedLauncher.GUI.ViewModels.Registry {
         public GithubModRegistryVM(GithubModRegistry registry, RequestDeletion? requestDeletion = null) : base(registry, requestDeletion) {
             Registry = registry;
         }
-        
+
         [DependsOn(nameof(Org), nameof(RepoName))]
         public string Name => Registry.Name;
 
@@ -137,7 +137,7 @@ namespace UnchainedLauncher.GUI.ViewModels.Registry {
             set => Registry.RepoName = value;
         }
     }
-    
+
     [AddINotifyPropertyChangedInterface]
     public partial class LocalModRegistryVM : GenericModRegistryVM {
         public new LocalModRegistry Registry { get; private set; }
@@ -145,7 +145,7 @@ namespace UnchainedLauncher.GUI.ViewModels.Registry {
         public LocalModRegistryVM(LocalModRegistry registry, RequestDeletion? requestDeletion = null) : base(registry, requestDeletion) {
             Registry = registry;
         }
-        
+
         [DependsOn(nameof(RegistryPath))]
         public string Name => Registry.Name;
 
@@ -161,7 +161,7 @@ namespace UnchainedLauncher.GUI.ViewModels.Registry {
                         $"Unsure how to mutate downloader of type '{Registry.ModRegistryDownloader.GetType().Name}' to use new pak dir"
                         );
                 }
-            } 
+            }
         }
 
         public string AbsoluteStub => FileSystem.CurrentDirectory;

--- a/UnchainedLauncher.GUI/Views/DesignInstances/MainWindowViewModelInstances.cs
+++ b/UnchainedLauncher.GUI/Views/DesignInstances/MainWindowViewModelInstances.cs
@@ -1,4 +1,5 @@
 ﻿using UnchainedLauncher.GUI.ViewModels;
+using UnchainedLauncher.GUI.ViewModels.Registry;
 
 namespace UnchainedLauncher.GUI.Views.DesignInstances {
     public static class MainWindowViewModelInstances {
@@ -6,7 +7,8 @@ namespace UnchainedLauncher.GUI.Views.DesignInstances {
             LauncherViewModelInstances.DEFAULT,
             ModListViewModelInstances.DEFAULT,
             SettingsViewModelInstances.DEFAULT,
-            ServersTabInstances.DEFAULT
+            ServersTabInstances.DEFAULT,
+            RegistryTabVM.DEFAULT
         );
     }
 }

--- a/UnchainedLauncher.GUI/Views/DesignInstances/RegistryTabViewModelInstances.cs
+++ b/UnchainedLauncher.GUI/Views/DesignInstances/RegistryTabViewModelInstances.cs
@@ -1,0 +1,7 @@
+using UnchainedLauncher.GUI.ViewModels.Registry;
+
+namespace UnchainedLauncher.GUI.Views.DesignInstances {
+    public static class RegistryTabViewModelInstances {
+        public static RegistryTabVM DEFAULT => RegistryTabVM.DEFAULT;
+    }
+}

--- a/UnchainedLauncher.GUI/Views/MainWindow.xaml
+++ b/UnchainedLauncher.GUI/Views/MainWindow.xaml
@@ -6,6 +6,7 @@
         xmlns:local="clr-namespace:UnchainedLauncher.GUI.Views"
         xmlns:vms="clr-namespace:UnchainedLauncher.GUI.ViewModels"
         xmlns:instances="clr-namespace:UnchainedLauncher.GUI.Views.DesignInstances"
+        xmlns:registry="clr-namespace:UnchainedLauncher.GUI.Views.Registry"
         mc:Ignorable="d" 
         d:DataContext="{x:Static instances:MainWindowViewModelInstances.DEFAULT}"
         x:Class="UnchainedLauncher.GUI.Views.MainWindow"
@@ -37,6 +38,9 @@
     <TabControl x:Name="Tabs">
         <TabItem Header="Launcher">
             <local:Launcher DataContext="{Binding LauncherViewModel}" />
+        </TabItem>
+        <TabItem Header="Mod Registries">
+            <registry:RegistryTab DataContext="{Binding RegistryTabViewModel}"/>
         </TabItem>
         <TabItem Header="Mod Manager">
             <local:ModList DataContext="{Binding ModListViewModel}" />

--- a/UnchainedLauncher.GUI/Views/Registry/RegistryTab.xaml
+++ b/UnchainedLauncher.GUI/Views/Registry/RegistryTab.xaml
@@ -28,7 +28,7 @@
                     <Label Grid.Row="1" Grid.Column="0">RepoName:</Label>
                     <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding RepoName}"/>
                 </Grid>
-                
+                <Button Command="{Binding SelfDeleteCommand}">Delete</Button>
                 
             </StackPanel>
         </DataTemplate>
@@ -53,20 +53,36 @@
                         <TextBox Text="{Binding RegistryPath}"/>
                     </StackPanel>
                 </Grid>
+                <Button Command="{Binding SelfDeleteCommand}">Delete</Button>
             </StackPanel>
+            
         </DataTemplate>
         <DataTemplate DataType="{x:Type registry:GenericModRegistryVM}">
-            <TextBlock Text="{Binding Registry.Name, Mode=OneWay}"/>
+            <StackPanel>
+                <TextBlock Text="{Binding Registry.Name, Mode=OneWay}"/>
+                <Button Command="{Binding SelfDeleteCommand}">Delete</Button>
+            </StackPanel>
+            
         </DataTemplate>
     </UserControl.Resources>
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="auto"/>
             <RowDefinition Height="*"/>
+            <RowDefinition Height="auto"/>
         </Grid.RowDefinitions>
         <TextBlock Grid.Row="0">Viewmodel instances: <Run Text="{Binding Registries.Count, Mode=OneWay}"/></TextBlock>
-        <ListView Grid.Row="1" ItemsSource="{Binding Registries}">
-            
-        </ListView>
+        <ListView Grid.Row="1" ItemsSource="{Binding Registries}"/>
+        <Grid Grid.Row="2">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="auto"/>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Button Grid.Column="1" Command="{Binding AddNewGithubRegistryCommand}">Add Github Registry</Button>
+            <Button Grid.Column="3" Command="{Binding AddNewLocalRegistryCommand}">Add Local Registry</Button>
+        </Grid>
     </Grid>
 </UserControl>

--- a/UnchainedLauncher.GUI/Views/Registry/RegistryTab.xaml
+++ b/UnchainedLauncher.GUI/Views/Registry/RegistryTab.xaml
@@ -1,0 +1,46 @@
+<UserControl x:Class="UnchainedLauncher.GUI.Views.Registry.RegistryTab"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:UnchainedLauncher.GUI.Views.Registry"
+             xmlns:instances="clr-namespace:UnchainedLauncher.GUI.Views.DesignInstances"
+             xmlns:registry="clr-namespace:UnchainedLauncher.GUI.ViewModels.Registry"
+             d:DataContext="{x:Static instances:RegistryTabViewModelInstances.DEFAULT}"
+             mc:Ignorable="d"
+             d:DesignHeight="300" d:DesignWidth="300" >
+    <UserControl.Resources>
+        <DataTemplate DataType="{x:Type registry:GithubModRegistryVM}">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" Text="{Binding _registry.Name}"/>
+                <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal">
+                    <Label>Organization:</Label>
+                    <TextBox Text="{Binding Org}"/>
+                </StackPanel>
+                <StackPanel Grid.Row="1" Grid.Column="2" Orientation="Horizontal">
+                    <Label>RepoName:</Label>
+                    <TextBox Text="{Binding RepoName}"/>
+                </StackPanel>
+            </Grid>
+        </DataTemplate>
+    </UserControl.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <TextBlock Grid.Row="0">Viewmodel instances: <Run Text="{Binding Registries.Count, Mode=OneWay}"/></TextBlock>
+        <ListView Grid.Row="1" ItemsSource="{Binding Registries}">
+            
+        </ListView>
+    </Grid>
+</UserControl>

--- a/UnchainedLauncher.GUI/Views/Registry/RegistryTab.xaml
+++ b/UnchainedLauncher.GUI/Views/Registry/RegistryTab.xaml
@@ -11,26 +11,52 @@
              d:DesignHeight="300" d:DesignWidth="300" >
     <UserControl.Resources>
         <DataTemplate DataType="{x:Type registry:GithubModRegistryVM}">
-            <Grid>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
-                <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3" Text="{Binding _registry.Name}"/>
-                <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal">
-                    <Label>Organization:</Label>
-                    <TextBox Text="{Binding Org}"/>
-                </StackPanel>
-                <StackPanel Grid.Row="1" Grid.Column="2" Orientation="Horizontal">
-                    <Label>RepoName:</Label>
-                    <TextBox Text="{Binding RepoName}"/>
-                </StackPanel>
-            </Grid>
+            <StackPanel>
+                <TextBlock Text="{Binding Name}"/>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Label Grid.Row="0" Grid.Column="0">Organization:</Label>
+                    <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding Org}"/>
+                
+                    <Label Grid.Row="1" Grid.Column="0">RepoName:</Label>
+                    <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding RepoName}"/>
+                </Grid>
+                
+                
+            </StackPanel>
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type registry:LocalModRegistryVM}">
+            <StackPanel>
+                <TextBlock Text="{Binding Name}"/>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Label Grid.Row="0" Grid.Column="0">Registry Path:</Label>
+                    <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal">
+                        <TextBlock ToolTip="{Binding AbsoluteStub, Mode=OneWay}">
+                            <Run Text="&lt;Base Dir&gt;"/>
+                            <Run Text="{Binding PathSeparator, Mode=OneWay}"/>
+                            <Run Text=" "/>
+                        </TextBlock>
+                        <TextBox Text="{Binding RegistryPath}"/>
+                    </StackPanel>
+                </Grid>
+            </StackPanel>
+        </DataTemplate>
+        <DataTemplate DataType="{x:Type registry:GenericModRegistryVM}">
+            <TextBlock Text="{Binding Registry.Name, Mode=OneWay}"/>
         </DataTemplate>
     </UserControl.Resources>
     <Grid>

--- a/UnchainedLauncher.GUI/Views/Registry/RegistryTab.xaml.cs
+++ b/UnchainedLauncher.GUI/Views/Registry/RegistryTab.xaml.cs
@@ -1,0 +1,9 @@
+using System.Windows.Controls;
+
+namespace UnchainedLauncher.GUI.Views.Registry {
+    public partial class RegistryTab : UserControl {
+        public RegistryTab() {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
Adds a tab for adding, deleting, and editing the registry(s) backing the mod managers. This tab might get moved to a pop-up somewhere, but for now I think it's fine to put it in a tab until we sort out registry saving/reloading.